### PR TITLE
Feature/context handler implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 .idea
+.vscode
 # C extensions
 *.so
 

--- a/bazaar/bazaar.py
+++ b/bazaar/bazaar.py
@@ -7,8 +7,8 @@ import re
 
 FileAttrs = namedtuple('FileAttrs', ["created", "updated", "name", "size", "namespace"])
 
-FILE_NEEDED_FIELDS = ('_id', 'name', 'namespace')
-FILE_PROJECT = {f: -1 for f in FILE_NEEDED_FIELDS}
+FILE_NEEDED_FIELDS = {'_id', 'name', 'namespace'}
+FILE_PROJECT = {f: True for f in FILE_NEEDED_FIELDS}
 
 
 # class File(Document):

--- a/bazaar/bazaar.py
+++ b/bazaar/bazaar.py
@@ -47,6 +47,16 @@ class BufferWrapper(object):
         else:
             return orig_attr
 
+    # These following two methods can't be dynamically queried through the __getattr__ method.
+    def __enter__(self, *args, **kwargs):
+        """Needed to implement the context handler - with FileSystem.open() as... -."""
+        result = self.wrapped_object.__enter__(*args, **kwargs)
+        return self if result == self.wrapped_object else result
+
+    def __exit__(self, *args, **kwargs):
+        """Needed to implement the context handler - with FileSystem.open() as... -."""
+        return self.wrapped_object.__exit__(*args, **kwargs)
+
 
 class FileSystem(object):
 

--- a/bazaar/bazaar.py
+++ b/bazaar/bazaar.py
@@ -2,13 +2,16 @@ from pymongo import MongoClient
 from collections import namedtuple
 from fs import open_fs
 from datetime import datetime
+import io
 import os
 import re
 
+
 FileAttrs = namedtuple('FileAttrs', ["created", "updated", "name", "size", "namespace"])
 
-FILE_NEEDED_FIELDS = {'_id', 'name', 'namespace'}
+FILE_NEEDED_FIELDS = {'_id', 'name', 'namespace', 'size'}
 FILE_PROJECT = {f: True for f in FILE_NEEDED_FIELDS}
+FILE_SIZE_CHANGING_MODES = {'w', 'a', 'x'}
 
 
 # class File(Document):
@@ -33,11 +36,7 @@ class BufferWrapper(object):
         if callable(orig_attr):
             def hooked(*args, **kwargs):
                 if attr == "close":
-                    file_size = self.wrapped_object.tell()
-                    r = self.db.update_one({"name": self.file_data["name"], "namespace": self.file_data["namespace"]}, {"$set": {"size": file_size}})
-                    # In case source does not exist, matched_count is 0
-                    if r.matched_count == 0:
-                        raise Exception("Cannot update size of a non existent file")
+                    self.update_file_size_if_needed()
                 result = orig_attr(*args, **kwargs)
                 if result == self.wrapped_object:
                     return self
@@ -55,7 +54,28 @@ class BufferWrapper(object):
 
     def __exit__(self, *args, **kwargs):
         """Needed to implement the context handler - with FileSystem.open() as... -."""
+        self.update_file_size_if_needed()
         return self.wrapped_object.__exit__(*args, **kwargs)
+
+    def update_file_size_if_needed(self) -> bool:
+        if self.can_mode_change_size():
+            new_size = self.wrapped_object.tell()
+            if self.file_data['size'] != new_size:
+                self.update_file_size(new_size)
+                return True
+        return False
+
+    def can_mode_change_size(self):
+        return self.wrapped_object.mode[0] in FILE_SIZE_CHANGING_MODES
+
+    def update_file_size(self, new_size: int):
+        update_result = self.db.update_one(
+            {"name": self.file_data["name"], "namespace": self.file_data["namespace"]},
+            {"$set": {"size": new_size}}
+        )
+        # In case source does not exist, matched_count is 0
+        if update_result.matched_count == 0:
+            raise Exception("Cannot update size of a non existent file")
 
 
 class FileSystem(object):

--- a/bazaar/test/test.py
+++ b/bazaar/test/test.py
@@ -1,14 +1,20 @@
+import io
 import unittest
 import shutil
 import os
 import logging
 
+from pymongo import MongoClient
+
 try:
-    from bazaar.bazaar import FileSystem
+    from bazaar.bazaar import BufferWrapper, FileSystem
 except ImportError:
     import sys
-    sys.path.insert(1, '..')
-    from bazaar.bazaar import FileSystem
+    sys.path.insert(1, '.')
+    from bazaar.bazaar import BufferWrapper, FileSystem
+
+
+TEST_MONGO_URI = "mongodb://localhost/bazaar_test"
 
 
 class TestFileSystem(unittest.TestCase):
@@ -18,7 +24,7 @@ class TestFileSystem(unittest.TestCase):
         if os.path.exists(tmp_dir):
             shutil.rmtree(tmp_dir)
         os.mkdir(tmp_dir)
-        self.fs = FileSystem(tmp_dir, db_uri="mongodb://localhost/bazaar_test")
+        self.fs = FileSystem(tmp_dir, db_uri=TEST_MONGO_URI)
         self.fs.db.drop()
 
     def test_create_file(self):
@@ -177,11 +183,100 @@ class TestFileSystem(unittest.TestCase):
         example_file.close()
 
     def _open_existing_file(self):
+        path, namespace = self._create_hello_world_file()
+        example_file = self.fs.open(path, 'r', namespace=namespace)
+        example_file.close()
+
+    def test_open_context_handler(self):
+        path, namespace = self._create_hello_world_file()
+        with self.fs.open(path, 'r', namespace=namespace) as hello_world_file:
+            self.assertEqual(hello_world_file.read(), 'Hello world!')
+
+    def _create_hello_world_file(self):
         path = 'example.txt'
         namespace = 'example-namespace'
         self.fs.put(path, b'Hello world!', namespace=namespace)
-        example_file = self.fs.open(path, 'r', namespace=namespace)
-        example_file.close()
+        return path, namespace
+
+
+class TestBufferWrapper(unittest.TestCase):
+    test_file_dict = {'name': 'test_file', 'namespace': 'test-namespace'}
+
+    def setUp(self):
+        self.mongo_client = MongoClient(host=TEST_MONGO_URI)
+        self.db = self.mongo_client.get_default_database().file
+        self.db.drop()
+
+    def wrapper_factory(self, wrapped_object=None, file_data=None, default_mode='r'):
+        wrapped_object = wrapped_object or io.TextIOWrapper(io.BytesIO())
+        wrapped_object.mode = getattr(wrapped_object, 'mode', None) or default_mode
+        file_data = file_data or {'name': 'test_file', 'namespace': 'test-namespace'}
+        return BufferWrapper(wrapped_object=wrapped_object, file_data=file_data, db=self.db)
+
+    def test_context_handler(self):
+        wrapper = self.wrapper_factory()
+        with wrapper as context_handled:
+            self.assertEqual(wrapper, context_handled)
+
+    def test_can_mode_change_size(self):
+        wrapper = self.wrapper_factory(default_mode='r')
+        self.assertFalse(wrapper.can_mode_change_size())
+
+        for mode in {'w', 'w+', 'a', 'x'}:
+            wrapper = self.wrapper_factory(default_mode=mode)
+            self.assertTrue(wrapper.can_mode_change_size())
+
+    def test_update_file_size_non_existent(self):
+        wrapper = self.wrapper_factory()
+        with self.assertRaises(Exception) as e:
+            wrapper.update_file_size(new_size=10)
+        self.assertEqual(str(e.exception), 'Cannot update size of a non existent file')
+
+    def create_test_file(self):
+        test_file_data = self.test_file_dict.copy()
+        test_file_data['size'] = 0
+        self.db.insert_one(test_file_data)
+        return test_file_data
+
+    def test_update_file_size_existent(self):
+        file_data = self.create_test_file()
+        wrapper = self.wrapper_factory(file_data=file_data)
+        self.assertEqual(wrapper.file_data['size'], 0)
+
+        wrapper.update_file_size(10)
+        updated_file_data = self.db.find_one(self.test_file_dict)
+        self.assertEqual(updated_file_data['size'], 10)
+
+    def test_update_file_size_if_needed_read_mode(self):
+        file_data = self.create_test_file()
+        wrapper = self.wrapper_factory(file_data=file_data)
+        self.assertFalse(wrapper.update_file_size_if_needed())
+
+    def test_update_file_size_if_needed_write_mode_no_size_change(self):
+        file_data = self.create_test_file()
+        wrapper = self.wrapper_factory(file_data=file_data, default_mode='w')
+        self.assertFalse(wrapper.update_file_size_if_needed())
+
+    def test_update_file_size_if_needed_write_mode_size_change(self):
+        file_data = self.create_test_file()
+        wrapper = self.wrapper_factory(file_data=file_data, default_mode='w')
+        wrapper.wrapped_object.write('Hello world!')
+        self.assertTrue(wrapper.update_file_size_if_needed())
+
+    def test_close_updates_file_size(self):
+        file_data = self.create_test_file()
+        wrapper = self.wrapper_factory(file_data=file_data, default_mode='w')
+        new_size = wrapper.wrapped_object.write('Hello world!')
+        wrapper.close()
+        updated_file_data = self.db.find_one(self.test_file_dict)
+        self.assertEqual(updated_file_data['size'], new_size)
+
+    def test_context_handler_updates_file_size(self):
+        file_data = self.create_test_file()
+        with self.wrapper_factory(file_data=file_data, default_mode='w') as wrapper:
+            new_size = wrapper.wrapped_object.write('Hello world!')
+        updated_file_data = self.db.find_one(self.test_file_dict)
+        self.assertEqual(updated_file_data['size'], new_size)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as fp:
 setup(
     name='bazaar',
     packages=['bazaar'],
-    version='1.0.1',
+    version='1.1.0',
     description='Agnostic file storage',
     author='BMAT developers',
     author_email='tv-av@bmat.com',


### PR DESCRIPTION
Howdy @maxpowel !

This Pull Request gives bazaar two important updates.

The first one is allowing FileSystem.open method to be used as a context handler which I consider the most reasonable behaviour since its nowadays the encouraged way of using, for instance, Python's builtin open function.

The second one is consistent with dropping Mongoengine for performance reasons. Instead of querying the database every time we close a file to update its size and waste the request time, only send a request for the database in case the file size has actually changed. It might be just a detail but I find it to be the most consistent approach.

Obviously, tests were added for both features as well and all of them pass flawlessly.