### PR TITLE
Add get_id() method to FileSystem

### DIFF
--- a/bazaar/bazaar.py
+++ b/bazaar/bazaar.py
@@ -1,14 +1,13 @@
-from typing import Optional
-
-import mongomock
-from pymongo import MongoClient
-from collections import namedtuple
-from fs import open_fs
-from datetime import datetime
 import io
 import os
 import re
+from collections import namedtuple
+from datetime import datetime
+from typing import Optional
 
+import mongomock
+from fs import open_fs
+from pymongo import MongoClient
 
 FileAttrs = namedtuple('FileAttrs', ["created", "updated", "name", "size", "namespace"])
 
@@ -160,7 +159,10 @@ class FileSystem(object):
             return False
 
         # Perform the update
-        r = self.db.update_one({"name": path, "namespace": from_namespace}, {"$set": {"namespace": to_namespace, "updated": datetime.utcnow()}})
+        r = self.db.update_one(
+            {"name": path, "namespace": from_namespace},
+            {"$set": {"namespace": to_namespace, "updated": datetime.utcnow()}}
+            )
         # In case source does not exist, matched_count is 0
         return r.matched_count > 0
 
@@ -170,7 +172,10 @@ class FileSystem(object):
             namespace = self.namespace
 
         # Perform the update
-        r = self.db.update_one({"name": path, "namespace": namespace}, {"$set": {"extras": extras, "updated": datetime.utcnow()}})
+        r = self.db.update_one(
+            {"name": path, "namespace": namespace},
+            {"$set": {"extras": extras, "updated": datetime.utcnow()}}
+            )
         return r.matched_count > 0
 
     def get_extras(self, path, namespace=None):
@@ -193,16 +198,21 @@ class FileSystem(object):
         new_file = d is None
 
         if new_file:
-            insert_info = self.db.insert_one({
-                "name": path,
-                "namespace": namespace,
-                "created": datetime.utcnow(),
-                "updated": datetime.utcnow(),
-                "size": len(content)
-            })
+            insert_info = self.db.insert_one(
+                {
+                    "name": path,
+                    "namespace": namespace,
+                    "created": datetime.utcnow(),
+                    "updated": datetime.utcnow(),
+                    "size": len(content)
+                }
+            )
             filename = str(insert_info.inserted_id)
         else:
-            self.db.update_one({"name": path, "namespace": namespace}, {"$set": {"size": len(content), "updated": datetime.utcnow()}})
+            self.db.update_one(
+                {"name": path, "namespace": namespace},
+                {"$set": {"size": len(content), "updated": datetime.utcnow()}}
+                )
             filename = str(d["_id"])
 
         try:
@@ -214,7 +224,10 @@ class FileSystem(object):
                 self.db.delete_one({"name": path, "namespace": namespace})
             else:
                 # Backup data
-                self.db.update_one({"name": path, "namespace": namespace}, {"$set": {"size": d["size"], "updated": d["updated"]}})
+                self.db.update_one(
+                    {"name": path, "namespace": namespace},
+                    {"$set": {"size": d["size"], "updated": d["updated"]}}
+                    )
             raise e
 
     def list(self, path, namespace=None):
@@ -310,4 +323,3 @@ class FileSystem(object):
         if db_object is not None:
             return db_object["_id"]
         return None
-

--- a/bazaar/test/test.py
+++ b/bazaar/test/test.py
@@ -10,6 +10,7 @@ try:
     from bazaar.bazaar import BufferWrapper, FileSystem
 except ImportError:
     import sys
+
     sys.path.insert(1, '.')
     from bazaar.bazaar import BufferWrapper, FileSystem
 
@@ -176,7 +177,9 @@ class TestFileSystem(unittest.TestCase):
         self.assertTrue(self.fs.exists(path="/original", namespace=namespace_2))
 
         # wrong cases
-        self.assertFalse(self.fs.change_namespace(path="/not_exists", from_namespace=namespace, to_namespace=namespace_2))
+        self.assertFalse(
+            self.fs.change_namespace(path="/not_exists", from_namespace=namespace, to_namespace=namespace_2)
+        )
         self.fs.put(namespace=namespace, path="/original", content="a".encode())
         self.assertFalse(self.fs.change_namespace(path="/original", from_namespace=namespace, to_namespace=namespace_2))
 


### PR DESCRIPTION
- Add get_id method, a method that returns the file's id in the
  database/name in the filesystem
- Add test for new get_id method
- Add optional testing with mongomock via env variable
  (retains backwards compatibility by defaulting to False)